### PR TITLE
Update Titanic.py

### DIFF
--- a/Titanic Dataset/Titanic.py
+++ b/Titanic Dataset/Titanic.py
@@ -73,7 +73,7 @@ class TestTitanicOperations(unittest.TestCase):
 
         self.assertAlmostEqual(average_age, 35.6, places=1)
 
-if name == 'main':
+if __name__ == '__main__':
     unittest.main()
     
 # Titanic Train CSV file


### PR DESCRIPTION
corrected the 

```
if __name__ == '__main__':
    unittest.main()
```

enclosure
